### PR TITLE
Add convert command

### DIFF
--- a/scripts/lib/convert.go
+++ b/scripts/lib/convert.go
@@ -49,7 +49,7 @@ func doConvert() error {
 		}
 		channelDir := filepath.Join(outDir, channel.Id)
 		if err := mkdir(channelDir); err != nil {
-			return fmt.Errorf("could not create %s/%s directory: %s", outDir, channel.Id, err)
+			return fmt.Errorf("could not create %s directory: %s", channelDir, err)
 		}
 		messagesPerDay := groupMessagesByDay(messages)
 		for key := range messagesPerDay {

--- a/scripts/lib/convert.go
+++ b/scripts/lib/convert.go
@@ -45,6 +45,7 @@ func doConvert() error {
 		}
 		for _, message := range messages {
 			message.UserProfile = nil
+			message.removeTokenFromURLs()
 		}
 		channelDir := filepath.Join(outDir, channel.Id)
 		if err := mkdir(channelDir); err != nil {

--- a/scripts/lib/convert.go
+++ b/scripts/lib/convert.go
@@ -88,12 +88,10 @@ func readAllMessages(inDir string) ([]*message, error) {
 	}
 	defer dir.Close()
 	names, err := dir.Readdirnames(0)
-	sort.SliceStable(names, func(i, j int) bool {
-		return names[i] < names[j]
-	})
 	if err != nil {
 		return nil, err
 	}
+	sort.Strings(names)
 	var messages []*message
 	for i := range names {
 		content, err := ioutil.ReadFile(filepath.Join(inDir, names[i]))

--- a/scripts/lib/convert.go
+++ b/scripts/lib/convert.go
@@ -1,0 +1,134 @@
+package slacklog
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+func doConvert() error {
+	if len(os.Args) < 4 {
+		fmt.Println("Usage: go run scripts/main.go convert {indir} {outdir}")
+		return nil
+	}
+
+	inDir := filepath.Clean(os.Args[2])
+	outDir := filepath.Clean(os.Args[3])
+
+	channels, _, err := readChannels(filepath.Join(inDir, "channels.json"), []string{"*"})
+	if err != nil {
+		return fmt.Errorf("could not read channels.json: %s", err)
+	}
+
+	if err := mkdir(outDir); err != nil {
+		return fmt.Errorf("could not create %s directory: %s", outDir, err)
+	}
+
+	err = copyFile(filepath.Join(inDir, "channels.json"), filepath.Join(outDir, "channels.json"))
+	if err != nil {
+		return err
+	}
+
+	err = copyFile(filepath.Join(inDir, "users.json"), filepath.Join(outDir, "users.json"))
+	if err != nil {
+		return err
+	}
+
+	for _, channel := range channels {
+		messages, err := readAllMessages(filepath.Join(inDir, channel.Name))
+		if err != nil {
+			return err
+		}
+		for _, message := range messages {
+			message.UserProfile = nil
+		}
+		channelDir := filepath.Join(outDir, channel.Id)
+		if err := mkdir(channelDir); err != nil {
+			return fmt.Errorf("could not create %s/%s directory: %s", outDir, channel.Id, err)
+		}
+		messagesPerDay := groupMessagesByDay(messages)
+		for key := range messagesPerDay {
+			err = writeMessages(filepath.Join(channelDir, key+".json"), messagesPerDay[key])
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func copyFile(from string, to string) error {
+	r, err := os.Open(from)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	w, err := os.Create(to)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	_, err = io.Copy(w, r)
+
+	return err
+}
+
+func readAllMessages(inDir string) ([]*message, error) {
+	dir, err := os.Open(inDir)
+	if err != nil {
+		return nil, err
+	}
+	defer dir.Close()
+	names, err := dir.Readdirnames(0)
+	sort.SliceStable(names, func(i, j int) bool {
+		return names[i] < names[j]
+	})
+	if err != nil {
+		return nil, err
+	}
+	var messages []*message
+	for i := range names {
+		content, err := ioutil.ReadFile(filepath.Join(inDir, names[i]))
+		if err != nil {
+			return nil, err
+		}
+		var msgs []*message
+		err = json.Unmarshal(content, &msgs)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, msgs...)
+	}
+	return messages, nil
+}
+
+func groupMessagesByDay(messages []*message) map[string][]*message {
+	messagesPerDay := map[string][]*message{}
+	for i := range messages {
+		time := ts2datetime(messages[i].Ts).Format("2006-01-02")
+		messagesPerDay[time] = append(messagesPerDay[time], messages[i])
+	}
+	return messagesPerDay
+}
+
+func writeMessages(filename string, messages []*message) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	encoder := json.NewEncoder(file)
+	encoder.SetEscapeHTML(false)
+	err = encoder.Encode(messages)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/scripts/lib/slacklog.go
+++ b/scripts/lib/slacklog.go
@@ -11,14 +11,17 @@ func Run() error {
 		fmt.Println("Usage: go run scripts/main.go {subcmd}")
 		fmt.Println("  Subcmd:")
 		fmt.Println("    - update")
+		fmt.Println("    - convert")
 		return nil
 	}
 
 	subCmdName := os.Args[1]
 	switch subCmdName {
+	case "convert":
+		return doConvert()
 	case "update":
 		return doUpdate()
 	}
 
-	return nil
+	return fmt.Errorf("Unknown subcmd: %s", subCmdName)
 }

--- a/scripts/lib/update.go
+++ b/scripts/lib/update.go
@@ -701,3 +701,24 @@ func filterChannel(channels []channel, cfgChannels []string) []channel {
 	}
 	return newChannels
 }
+
+var reToken = regexp.MustCompile(`\?t=xoxe-[-a-f0-9]+$`)
+
+func (m *message) removeTokenFromURLs() {
+	for i := range m.Files {
+		m.Files[i].UrlPrivate = reToken.ReplaceAllLiteralString(m.Files[i].UrlPrivate, "")
+		m.Files[i].UrlPrivateDownload = reToken.ReplaceAllLiteralString(m.Files[i].UrlPrivateDownload, "")
+		m.Files[i].Thumb64 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb64, "")
+		m.Files[i].Thumb80 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb80, "")
+		m.Files[i].Thumb160 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb160, "")
+		m.Files[i].Thumb360 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb360, "")
+		m.Files[i].Thumb480 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb480, "")
+		m.Files[i].Thumb720 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb720, "")
+		m.Files[i].Thumb800 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb800, "")
+		m.Files[i].Thumb960 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb960, "")
+		m.Files[i].Thumb1024 = reToken.ReplaceAllLiteralString(m.Files[i].Thumb1024, "")
+		m.Files[i].Thumb360Gif = reToken.ReplaceAllLiteralString(m.Files[i].Thumb360Gif, "")
+		m.Files[i].Thumb480Gif = reToken.ReplaceAllLiteralString(m.Files[i].Thumb480Gif, "")
+		m.Files[i].ThumbVideo = reToken.ReplaceAllLiteralString(m.Files[i].ThumbVideo, "")
+	}
+}

--- a/scripts/lib/update.go
+++ b/scripts/lib/update.go
@@ -206,25 +206,6 @@ func genChannelPerMonthIndex(inDir, tmplFile string, channel *channel, msgPerMon
 	var funcAttachmentText = func(attachment *messageAttachment) string {
 		return text2Html(attachment.Text)
 	}
-	var ts2datetime = func(ts string) time.Time {
-		t := strings.Split(ts, ".")
-		if len(t) != 2 {
-			return time.Time{}
-		}
-		sec, err := strconv.ParseInt(t[0], 10, 64)
-		if err != nil {
-			return time.Time{}
-		}
-		nsec, err := strconv.ParseInt(t[0], 10, 64)
-		if err != nil {
-			return time.Time{}
-		}
-		japan, err := time.LoadLocation("Asia/Tokyo")
-		if err != nil {
-			return time.Time{}
-		}
-		return time.Unix(sec, nsec).In(japan)
-	}
 	var ts2threadMtime = func(ts string) time.Time {
 		lastMsg := threadMap[ts][len(threadMap[ts])-1]
 		return ts2datetime(lastMsg.Ts)
@@ -294,6 +275,26 @@ func genChannelPerMonthIndex(inDir, tmplFile string, channel *channel, msgPerMon
 	}
 	err = t.Execute(&out, params)
 	return out.Bytes(), err
+}
+
+func ts2datetime(ts string) time.Time {
+	t := strings.Split(ts, ".")
+	if len(t) != 2 {
+		return time.Time{}
+	}
+	sec, err := strconv.ParseInt(t[0], 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	nsec, err := strconv.ParseInt(t[0], 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	japan, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(sec, nsec).In(japan)
 }
 
 func getDisplayNameByUserId(userId string, userMap map[string]*user) string {

--- a/scripts/lib/update.go
+++ b/scripts/lib/update.go
@@ -325,12 +325,10 @@ func getMsgPerMonth(inDir string, channelName string) (map[string]*msgPerMonth, 
 	}
 	defer dir.Close()
 	names, err := dir.Readdirnames(0)
-	sort.SliceStable(names, func(i, j int) bool {
-		return names[i] < names[j]
-	})
 	if err != nil {
 		return nil, nil, err
 	}
+	sort.Strings(names)
 	msgMap := make(map[string]*msgPerMonth)
 	threadMap := make(map[string][]*message)
 	for i := range names {

--- a/scripts/lib/update.go
+++ b/scripts/lib/update.go
@@ -286,7 +286,7 @@ func ts2datetime(ts string) time.Time {
 	if err != nil {
 		return time.Time{}
 	}
-	nsec, err := strconv.ParseInt(t[0], 10, 64)
+	nsec, err := strconv.ParseInt(t[1], 10, 64)
 	if err != nil {
 		return time.Time{}
 	}

--- a/scripts/lib/update.go
+++ b/scripts/lib/update.go
@@ -370,27 +370,30 @@ func getMsgPerMonth(inDir string, channelName string) (map[string]*msgPerMonth, 
 }
 
 type message struct {
-	ClientMsgId string              `json:"client_msg_id"`
-	Typ         string              `json:"type"`
-	Subtype     string              `json:"subtype"`
-	Text        string              `json:"text"`
-	User        string              `json:"user"`
-	Ts          string              `json:"ts"`
-	ThreadTs    string              `json:"thread_ts"`
-	Username    string              `json:"username"`
-	BotId       string              `json:"bot_id"`
-	Team        string              `json:"team"`
-	UserTeam    string              `json:"user_team"`
-	SourceTeam  string              `json:"source_team"`
-	UserProfile messageUserProfile  `json:"user_profile"`
-	Attachments []messageAttachment `json:"attachments"`
-	// Blocks      []messageBlock     `json:"blocks"`    // TODO
-	Reactions []messageReaction `json:"reactions"`
-	Edited    *messageEdited    `json:"edited"`
-	Icons     *messageIcons     `json:"icons"`
-	Files     []messageFile     `json:"files"`
-	Root      *message          `json:"root"`
-	Trail     bool              // if true, the message user the same as the previous one
+	ClientMsgId  string              `json:"client_msg_id,omitempty"`
+	Typ          string              `json:"type"`
+	Subtype      string              `json:"subtype,omitempty"`
+	Text         string              `json:"text"`
+	User         string              `json:"user"`
+	Ts           string              `json:"ts"`
+	ThreadTs     string              `json:"thread_ts,omitempty"`
+	ParentUserId string              `json:"parent_user_id,omitempty"`
+	Username     string              `json:"username,omitempty"`
+	BotId        string              `json:"bot_id,omitempty"`
+	Team         string              `json:"team,omitempty"`
+	UserTeam     string              `json:"user_team,omitempty"`
+	SourceTeam   string              `json:"source_team,omitempty"`
+	UserProfile  *messageUserProfile `json:"user_profile,omitempty"`
+	Attachments  []messageAttachment `json:"attachments,omitempty"`
+	Blocks       []interface{}       `json:"blocks,omitempty"` // TODO: Use messageBlock
+	Reactions    []messageReaction   `json:"reactions,omitempty"`
+	Edited       *messageEdited      `json:"edited,omitempty"`
+	Icons        *messageIcons       `json:"icons,omitempty"`
+	Files        []messageFile       `json:"files,omitempty"`
+	Root         *message            `json:"root,omitempty"`
+	DisplayAsBot bool                `json:"display_as_bot,omitempty"`
+	Upload       bool                `json:"upload,omitempty"`
+	Trail        bool                // if true, the message user the same as the previous one
 }
 
 type messageFile struct {
@@ -414,9 +417,37 @@ type messageFile struct {
 	Username           string `json:"username"`
 	UrlPrivate         string `json:"url_private"`
 	UrlPrivateDownload string `json:"url_private_download"`
+	Thumb64            string `json:"thumb_64,omitempty"`
+	Thumb80            string `json:"thumb_80,omitempty"`
+	Thumb160           string `json:"thumb_160,omitempty"`
+	Thumb360           string `json:"thumb_360,omitempty"`
+	Thumb360W          int64  `json:"thumb_360_w,omitempty"`
+	Thumb360H          int64  `json:"thumb_360_h,omitempty"`
+	Thumb480           string `json:"thumb_480,omitempty"`
+	Thumb480W          int64  `json:"thumb_480_w,omitempty"`
+	Thumb480H          int64  `json:"thumb_480_h,omitempty"`
+	Thumb720           string `json:"thumb_720,omitempty"`
+	Thumb720W          int64  `json:"thumb_720_w,omitempty"`
+	Thumb720H          int64  `json:"thumb_720_h,omitempty"`
+	Thumb800           string `json:"thumb_800,omitempty"`
+	Thumb800W          int64  `json:"thumb_800_w,omitempty"`
+	Thumb800H          int64  `json:"thumb_800_h,omitempty"`
+	Thumb960           string `json:"thumb_960,omitempty"`
+	Thumb960W          int64  `json:"thumb_960_w,omitempty"`
+	Thumb960H          int64  `json:"thumb_960_h,omitempty"`
+	Thumb1024          string `json:"thumb_1024,omitempty"`
+	Thumb1024W         int64  `json:"thumb_1024_w,omitempty"`
+	Thumb1024H         int64  `json:"thumb_1024_h,omitempty"`
+	Thumb360Gif        string `json:"thumb_360_gif,omitempty"`
+	Thumb480Gif        string `json:"thumb_480_gif,omitempty"`
+	DeanimateGif       string `json:"deanimate_gif,omitempty"`
+	ThumbTiny          string `json:"thumb_tiny,omitempty"`
+	OriginalW          int64  `json:"original_w,omitempty"`
+	OriginalH          int64  `json:"original_h,omitempty"`
+	ThumbVideo         string `json:"thumb_video,omitempty"`
 	Permalink          string `json:"permalink"`
 	PermalinkPublic    string `json:"permalink_public"`
-	EditLink           string `json:"edit_link"`
+	EditLink           string `json:"edit_link,omitempty"`
 	IsStarred          bool   `json:"is_starred"`
 	HasRichPreview     bool   `json:"has_rich_preview"`
 }
@@ -455,26 +486,26 @@ type messageBlockElement struct {
 }
 
 type messageAttachment struct {
-	ServiceName     string `json:"service_name"`
-	AuthorIcon      string `json:"author_icon"`
-	AuthorName      string `json:"author_name"`
-	AuthorSubname   string `json:"author_subname"`
-	Title           string `json:"title"`
-	TitleLink       string `json:"title_link"`
-	Text            string `json:"text"`
-	Fallback        string `json:"fallback"`
-	ThumbUrl        string `json:"thumb_url"`
-	FromUrl         string `json:"from_url"`
-	ThumbWidth      int    `json:"thumb_width"`
-	ThumbHeight     int    `json:"thumb_height"`
-	ServiceIcon     string `json:"service_icon"`
+	ServiceName     string `json:"service_name,omitempty"`
+	AuthorIcon      string `json:"author_icon,omitempty"`
+	AuthorName      string `json:"author_name,omitempty"`
+	AuthorSubname   string `json:"author_subname,omitempty"`
+	Title           string `json:"title,omitempty"`
+	TitleLink       string `json:"title_link,omitempty"`
+	Text            string `json:"text,omitempty"`
+	Fallback        string `json:"fallback,omitempty"`
+	ThumbUrl        string `json:"thumb_url,omitempty"`
+	FromUrl         string `json:"from_url,omitempty"`
+	ThumbWidth      int    `json:"thumb_width,omitempty"`
+	ThumbHeight     int    `json:"thumb_height,omitempty"`
+	ServiceIcon     string `json:"service_icon,omitempty"`
 	Id              int    `json:"id"`
-	OriginalUrl     string `json:"original_url"`
-	VideoHtml       string `json:"video_html"`
-	VideoHtmlWidth  int    `json:"video_html_width"`
-	VideoHtmlHeight int    `json:"video_html_height"`
-	Footer          string `json:"footer"`
-	FooterIcon      string `json:"footer_icon"`
+	OriginalUrl     string `json:"original_url,omitempty"`
+	VideoHtml       string `json:"video_html,omitempty"`
+	VideoHtmlWidth  int    `json:"video_html_width,omitempty"`
+	VideoHtmlHeight int    `json:"video_html_height,omitempty"`
+	Footer          string `json:"footer,omitempty"`
+	FooterIcon      string `json:"footer_icon,omitempty"`
 }
 
 type messageReaction struct {


### PR DESCRIPTION
Slack から export してきた JSON 群に対して、

- 発言毎に付いている `"user_profile"` を削除
- ファイルを JST で日付毎に分割
- JSON の改行/スペースを削除 (`users.json` と `channels.json` は手抜きで単純コピー)
- チャンネル名ではなくチャンネルIDのディレクトリへ出力

したものを吐き出す `convert` コマンドを実装しました。

Go 全然わからんので指摘歓迎。

Closes #15