### PR TITLE
Use original filename for downloaded files

### DIFF
--- a/scripts/lib/download_files.go
+++ b/scripts/lib/download_files.go
@@ -85,22 +85,22 @@ func urlToFilename(url string) string {
 	return url[i+1:]
 }
 
-func (f *messageFile) downloadURLs() []string {
-	return []string{
-		f.UrlPrivate,
-		f.Thumb64,
-		f.Thumb80,
-		f.Thumb160,
-		f.Thumb360,
-		f.Thumb480,
-		f.Thumb720,
-		f.Thumb800,
-		f.Thumb960,
-		f.Thumb1024,
-		f.Thumb360Gif,
-		f.Thumb480Gif,
-		f.DeanimateGif,
-		f.ThumbVideo,
+func (f *messageFile) downloadURLsAndSuffixes() map[string]string {
+	return map[string]string{
+		f.UrlPrivate:   "",
+		f.Thumb64:      "_64",
+		f.Thumb80:      "_80",
+		f.Thumb160:     "_160",
+		f.Thumb360:     "_360",
+		f.Thumb480:     "_480",
+		f.Thumb720:     "_720",
+		f.Thumb800:     "_800",
+		f.Thumb960:     "_960",
+		f.Thumb1024:    "_1024",
+		f.Thumb360Gif:  "_360",
+		f.Thumb480Gif:  "_480",
+		f.DeanimateGif: "_deanimate_gif",
+		f.ThumbVideo:   "_thumb_video",
 	}
 }
 
@@ -113,8 +113,8 @@ func (f *messageFile) downloadAll(outDir string, slackToken string) []error {
 
 	var errs []error
 
-	for _, url := range f.downloadURLs() {
-		err = f.downloadFile(fileBaseDir, url, slackToken)
+	for url, suffix := range f.downloadURLsAndSuffixes() {
+		err = f.downloadFile(fileBaseDir, url, suffix, slackToken)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -123,12 +123,34 @@ func (f *messageFile) downloadAll(outDir string, slackToken string) []error {
 	return errs
 }
 
-func (f *messageFile) downloadFile(outDir, url, slackToken string) error {
+func (f *messageFile) downloadFilename(url, suffix string) string {
+	ext := filepath.Ext(url)
+	nameExt := filepath.Ext(f.Name)
+	name := f.Name[:len(f.Name)-len(ext)]
+	if ext == "" {
+		ext = nameExt
+		if ext == "" {
+			ext = filetypeToExtension[f.Filetype]
+		}
+	}
+
+	filename := strings.ReplaceAll(name+suffix+ext, "/", "_")
+
+	// XXX: Jekyll doesn't publish files that name starts with some characters
+	if strings.HasPrefix(filename, "_") || strings.HasPrefix(filename, ".") {
+		filename = "files" + filename
+	}
+
+	return filename
+}
+
+func (f *messageFile) downloadFile(outDir, url, suffix, slackToken string) error {
 	if url == "" {
 		return nil
 	}
 
-	filename := urlToFilename(url)
+	filename := f.downloadFilename(url, suffix)
+
 	destFile := filepath.Join(outDir, filename)
 	if _, err := os.Stat(destFile); err == nil {
 		// Just skip already downloaded file
@@ -171,4 +193,129 @@ func downloadFile(url, destFile, slackToken string) error {
 	_, err = io.Copy(w, resp.Body)
 
 	return err
+}
+
+// https://api.slack.com/types/file
+var filetypeToExtension = map[string]string{
+	"auto":         "",             // Auto Detect Type,
+	"text":         ".txt",         // Plain Text,
+	"ai":           ".ai",          // Illustrator File,
+	"apk":          ".apk",         // APK,
+	"applescript":  ".applescript", // AppleScript,
+	"binary":       "",             // Binary,
+	"bmp":          ".bmp",         // Bitmap,
+	"boxnote":      ".boxnote",     // BoxNote,
+	"c":            ".c",           // C,
+	"csharp":       ".cs",          // C#,
+	"cpp":          ".cpp",         // C++,
+	"css":          ".css",         // CSS,
+	"csv":          ".csv",         // CSV,
+	"clojure":      ".clj",         // Clojure,
+	"coffeescript": ".coffee",      // CoffeeScript,
+	"cfm":          ".cfm",         // ColdFusion,
+	"d":            ".d",           // D,
+	"dart":         ".dart",        // Dart,
+	"diff":         ".diff",        // Diff,
+	"doc":          ".doc",         // Word Document,
+	"docx":         ".docx",        // Word document,
+	"dockerfile":   ".dockerfile",  // Docker,
+	"dotx":         ".dotx",        // Word template,
+	"email":        ".eml",         // Email,
+	"eps":          ".eps",         // EPS,
+	"epub":         ".epub",        // EPUB,
+	"erlang":       ".erl",         // Erlang,
+	"fla":          ".fla",         // Flash FLA,
+	"flv":          ".flv",         // Flash video,
+	"fsharp":       ".fs",          // F#,
+	"fortran":      ".f90",         // Fortran,
+	"gdoc":         ".gdoc",        // GDocs Document,
+	"gdraw":        ".gdraw",       // GDocs Drawing,
+	"gif":          ".gif",         // GIF,
+	"go":           ".go",          // Go,
+	"gpres":        ".gpres",       // GDocs Presentation,
+	"groovy":       ".groovy",      // Groovy,
+	"gsheet":       ".gsheet",      // GDocs Spreadsheet,
+	"gzip":         ".gz",          // GZip,
+	"html":         ".html",        // HTML,
+	"handlebars":   ".handlebars",  // Handlebars,
+	"haskell":      ".hs",          // Haskell,
+	"haxe":         ".hx",          // Haxe,
+	"indd":         ".indd",        // InDesign Document,
+	"java":         ".java",        // Java,
+	"javascript":   ".js",          // JavaScript/JSON,
+	"jpg":          ".jpeg",        // JPEG,
+	"keynote":      ".keynote",     // Keynote Document,
+	"kotlin":       ".kt",          // Kotlin,
+	"latex":        ".tex",         // LaTeX/sTeX,
+	"lisp":         ".lisp",        // Lisp,
+	"lua":          ".lua",         // Lua,
+	"m4a":          ".m4a",         // MPEG 4 audio,
+	"markdown":     ".md",          // Markdown (raw),
+	"matlab":       ".m",           // MATLAB,
+	"mhtml":        ".mhtml",       // MHTML,
+	"mkv":          ".mkv",         // Matroska video,
+	"mov":          ".mov",         // QuickTime video,
+	"mp3":          ".mp3",         // mp4,
+	"mp4":          ".mp4",         // MPEG 4 video,
+	"mpg":          ".mpeg",        // MPEG video,
+	"mumps":        ".m",           // MUMPS,
+	"numbers":      ".numbers",     // Numbers Document,
+	"nzb":          ".nzb",         // NZB,
+	"objc":         ".objc",        // Objective-C,
+	"ocaml":        ".ml",          // OCaml,
+	"odg":          ".odg",         // OpenDocument Drawing,
+	"odi":          ".odi",         // OpenDocument Image,
+	"odp":          ".odp",         // OpenDocument Presentation,
+	"ods":          ".ods",         // OpenDocument Spreadsheet,
+	"odt":          ".odt",         // OpenDocument Text,
+	"ogg":          ".ogg",         // Ogg Vorbis,
+	"ogv":          ".ogv",         // Ogg video,
+	"pages":        ".pages",       // Pages Document,
+	"pascal":       ".pp",          // Pascal,
+	"pdf":          ".pdf",         // PDF,
+	"perl":         ".pl",          // Perl,
+	"php":          ".php",         // PHP,
+	"pig":          ".pig",         // Pig,
+	"png":          ".png",         // PNG,
+	"post":         ".post",        // Slack Post,
+	"powershell":   ".ps1",         // PowerShell,
+	"ppt":          ".ppt",         // PowerPoint presentation,
+	"pptx":         ".pptx",        // PowerPoint presentation,
+	"psd":          ".psd",         // Photoshop Document,
+	"puppet":       ".pp",          // Puppet,
+	"python":       ".py",          // Python,
+	"qtz":          ".qtz",         // Quartz Composer Composition,
+	"r":            ".r",           // R,
+	"rtf":          ".rtf",         // Rich Text File,
+	"ruby":         ".rb",          // Ruby,
+	"rust":         ".rs",          // Rust,
+	"sql":          ".sql",         // SQL,
+	"sass":         ".sass",        // Sass,
+	"scala":        ".scala",       // Scala,
+	"scheme":       ".scm",         // Scheme,
+	"sketch":       ".sketch",      // Sketch File,
+	"shell":        ".sh",          // Shell,
+	"smalltalk":    ".st",          // Smalltalk,
+	"svg":          ".svg",         // SVG,
+	"swf":          ".swf",         // Flash SWF,
+	"swift":        ".swift",       // Swift,
+	"tar":          ".tar",         // Tarball,
+	"tiff":         ".tiff",        // TIFF,
+	"tsv":          ".tsv",         // TSV,
+	"vb":           ".vb",          // VB.NET,
+	"vbscript":     ".vbs",         // VBScript,
+	"vcard":        ".vcf",         // vCard,
+	"velocity":     ".vm",          // Velocity,
+	"verilog":      ".v",           // Verilog,
+	"wav":          ".wav",         // Waveform audio,
+	"webm":         ".webm",        // WebM,
+	"wmv":          ".wmv",         // Windows Media Video,
+	"xls":          ".xls",         // Excel spreadsheet,
+	"xlsx":         ".xlsx",        // Excel spreadsheet,
+	"xlsb":         ".xlsb",        // Excel Spreadsheet (Binary, Macro Enabled),
+	"xlsm":         ".xlsm",        // Excel Spreadsheet (Macro Enabled),
+	"xltx":         ".xltx",        // Excel template,
+	"xml":          ".xml",         // XML,
+	"yaml":         ".yaml",        // YAML,
+	"zip":          ".zip",         // Zip,
 }

--- a/scripts/lib/generate_html.go
+++ b/scripts/lib/generate_html.go
@@ -775,12 +775,14 @@ func (f *messageFile) TopLevelMimetype() string {
 }
 
 func (f *messageFile) OriginalFilePath() string {
-	return f.Id + "/" + urlToFilename(f.UrlPrivate)
+	suffix := f.downloadURLsAndSuffixes()[f.UrlPrivate]
+	return f.Id + "/" + url.PathEscape(f.downloadFilename(f.UrlPrivate, suffix))
 }
 
 func (f *messageFile) ThumbImagePath() string {
 	if f.Thumb1024 != "" {
-		return f.Id + "/" + urlToFilename(f.Thumb1024)
+		suffix := f.downloadURLsAndSuffixes()[f.Thumb1024]
+		return f.Id + "/" + url.PathEscape(f.downloadFilename(f.Thumb1024, suffix))
 	}
 	return f.OriginalFilePath()
 }
@@ -800,5 +802,6 @@ func (f *messageFile) ThumbImageHeight() int64 {
 }
 
 func (f *messageFile) ThumbVideoPath() string {
-	return f.Id + "/" + urlToFilename(f.ThumbVideo)
+	suffix := f.downloadURLsAndSuffixes()[f.ThumbVideo]
+	return f.Id + "/" + url.PathEscape(f.downloadFilename(f.ThumbVideo, suffix))
 }


### PR DESCRIPTION
日本語のファイル名などが `______` のような意味のないファイル名になってしまっていたため、ファイル名を以下のようにする。

- `"name"` フィールドのものを使う
- 拡張子はダウンロード URL のものを使う
  - これは、特に画像のサムネイル等については形式が変換されている場合があるため
- 拡張子が URL にも `"name"` にも付いていない場合は、`"filetype"` の値から対応表を使って拡張子を付ける
  - 静的サイトジェネレータを使っているため、ブラウザに少しでもファイルの種類の情報を与えるため
- ファイル名が `_` や `.` で始まるファイルは Jekyll が serve してくれないため、ファイル名に `files` と言う適当な prefix を追加する
  - Jekyll が serve しないパターンが他にあるかは未確認