### PR TITLE
read JSON from file directly

### DIFF
--- a/scripts/lib/channel.go
+++ b/scripts/lib/channel.go
@@ -1,8 +1,6 @@
 package slacklog
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"sort"
 )
 
@@ -19,12 +17,8 @@ type ChannelTable struct {
 // ChannelTable を生成する。
 // whitelistに指定したチャンネル名のみを読み込む。
 func NewChannelTable(path string, whitelist []string) (*ChannelTable, error) {
-	content, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
 	var channels []Channel
-	if err := json.Unmarshal(content, &channels); err != nil {
+	if err := ReadFileAsJSON(path, &channels); err != nil {
 		return nil, err
 	}
 	channels = FilterChannel(channels, whitelist)

--- a/scripts/lib/config.go
+++ b/scripts/lib/config.go
@@ -1,10 +1,5 @@
 package slacklog
 
-import (
-	"encoding/json"
-	"io/ioutil"
-)
-
 // Config : ログ出力時の設定を保持する。
 type Config struct {
 	EditedSuffix string   `json:"edited_suffix"`
@@ -14,12 +9,8 @@ type Config struct {
 
 // ReadConfig : pathに指定したファイルからコンフィグを読み込む。
 func ReadConfig(path string) (*Config, error) {
-	content, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
 	var cfg Config
-	if err := json.Unmarshal(content, &cfg); err != nil {
+	if err := ReadFileAsJSON(path, &cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil

--- a/scripts/lib/emoji.go
+++ b/scripts/lib/emoji.go
@@ -1,8 +1,6 @@
 package slacklog
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"os"
 )
 
@@ -25,12 +23,7 @@ func NewEmojiTable(path string) (*EmojiTable, error) {
 		return nil, os.ErrNotExist
 	}
 
-	content, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(content, &emojis.URLMap); err != nil {
+	if err := ReadFileAsJSON(path, &emojis.URLMap); err != nil {
 		return nil, err
 	}
 

--- a/scripts/lib/json.go
+++ b/scripts/lib/json.go
@@ -1,0 +1,21 @@
+package slacklog
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// ReadFileAsJSON reads a file and unmarshal its contents as JSON to `dst`
+// destination object.
+func ReadFileAsJSON(filename string, dst interface{}) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	err = json.NewDecoder(f).Decode(dst)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/scripts/lib/message.go
+++ b/scripts/lib/message.go
@@ -1,9 +1,7 @@
 package slacklog
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -81,13 +79,9 @@ func (m *MessageTable) ReadLogFile(path string) error {
 		return nil
 	}
 
-	content, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
 	var msgs []Message
 	var visibleMsgs []Message
-	err = json.Unmarshal(content, &msgs)
+	err = ReadFileAsJSON(path, &msgs)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal %s: %w", path, err)
 	}

--- a/scripts/lib/subcmd/convert_exported_logs.go
+++ b/scripts/lib/subcmd/convert_exported_logs.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -91,12 +90,8 @@ func copyFile(from string, to string) error {
 }
 
 func readChannels(channelsJsonPath string, cfgChannels []string) ([]slacklog.Channel, map[string]*slacklog.Channel, error) {
-	content, err := ioutil.ReadFile(channelsJsonPath)
-	if err != nil {
-		return nil, nil, err
-	}
 	var channels []slacklog.Channel
-	err = json.Unmarshal(content, &channels)
+	err := slacklog.ReadFileAsJSON(channelsJsonPath, &channels)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,12 +119,8 @@ func ReadAllMessages(inDir string) ([]*slacklog.Message, error) {
 	sort.Strings(names)
 	var messages []*slacklog.Message
 	for i := range names {
-		content, err := ioutil.ReadFile(filepath.Join(inDir, names[i]))
-		if err != nil {
-			return nil, err
-		}
 		var msgs []*slacklog.Message
-		err = json.Unmarshal(content, &msgs)
+		err := slacklog.ReadFileAsJSON(filepath.Join(inDir, names[i]), &msgs)
 		if err != nil {
 			return nil, err
 		}

--- a/scripts/lib/user.go
+++ b/scripts/lib/user.go
@@ -1,10 +1,5 @@
 package slacklog
 
-import (
-	"encoding/json"
-	"io/ioutil"
-)
-
 // UserTable : ユーザデータを保持する
 // UsersもUserMapも保持するユーザデータは同じで、UserMapはユーザIDをキーとする
 // mapとなっている。
@@ -18,12 +13,8 @@ type UserTable struct {
 // NewUserTable : pathに指定したJSON形式のユーザデータを読み込み、UserTableを生
 // 成する。
 func NewUserTable(path string) (*UserTable, error) {
-	content, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
 	var users []User
-	err = json.Unmarshal(content, &users)
+	err := ReadFileAsJSON(path, &users)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
メモリの節約とコードの整理を兼ねて、
ファイルからJSONを直接Unmarshalする関数 `ReadFileAsJSON()` を作り、
それを使える場所を全部置き換えました。

一部の修正は #64 と conflict すると思うので
どちらかがマージされた後にもう片方を直します。