### PR TITLE
forループ内のインデックスを可能な限り排除

### DIFF
--- a/scripts/lib/channel.go
+++ b/scripts/lib/channel.go
@@ -26,26 +26,34 @@ func NewChannelTable(path string, whitelist []string) (*ChannelTable, error) {
 		return channels[i].Name < channels[j].Name
 	})
 	channelMap := make(map[string]*Channel, len(channels))
-	for i := range channels {
-		channelMap[channels[i].ID] = &channels[i]
+	for i, ch := range channels {
+		channelMap[ch.ID] = &channels[i]
 	}
-	return &ChannelTable{channels, channelMap}, nil
+	return &ChannelTable{
+		Channels:   channels,
+		ChannelMap: channelMap,
+	}, nil
 }
 
 // FilterChannel : whitelistに指定したチャンネル名に該当するチャンネルのみを返
 // す。
 // whitelistに'*'が含まれる場合はchannelをそのまま返す。
 func FilterChannel(channels []Channel, whitelist []string) []Channel {
-	newChannels := make([]Channel, 0, len(channels))
-	for i := range whitelist {
-		if whitelist[i] == "*" {
+	if len(whitelist) == 0 {
+		return []Channel{}
+	}
+	allowed := map[string]struct{}{}
+	for _, s := range whitelist {
+		if s == "*" {
 			return channels
 		}
-		for j := range channels {
-			if whitelist[i] == channels[j].Name {
-				newChannels = append(newChannels, channels[j])
-				break
-			}
+		allowed[s] = struct{}{}
+	}
+	newChannels := make([]Channel, 0, len(whitelist))
+	for _, ch := range channels {
+		_, ok := allowed[ch.Name]
+		if ok {
+			newChannels = append(newChannels, ch)
 		}
 	}
 	return newChannels

--- a/scripts/lib/converter.go
+++ b/scripts/lib/converter.go
@@ -103,18 +103,19 @@ func (c *TextConverter) ToHTML(text string) string {
 	text = c.escapeSpecialChars(text)
 	text = c.re.newLine.ReplaceAllString(text, "<br>")
 	chunks := c.re.code.Split(text, -1)
-	for i := range chunks {
+	for i, s := range chunks {
 		if i%2 == 0 {
-			chunks[i] = c.re.linkWithTitle.ReplaceAllString(chunks[i], "<a href='${1}'>${2}</a>")
-			chunks[i] = c.re.link.ReplaceAllString(chunks[i], "<a href='${1}'>${1}</a>")
-			chunks[i] = c.re.codeShort.ReplaceAllString(chunks[i], "<code>${1}</code>")
-			chunks[i] = c.re.del.ReplaceAllString(chunks[i], "<del>${1}</del>")
-			chunks[i] = c.re.emoji.ReplaceAllStringFunc(chunks[i], c.bindEmoji)
-			chunks[i] = c.re.mention.ReplaceAllStringFunc(chunks[i], c.bindUser)
-			chunks[i] = c.re.channel.ReplaceAllStringFunc(chunks[i], c.bindChannel)
+			s = c.re.linkWithTitle.ReplaceAllString(s, "<a href='${1}'>${2}</a>")
+			s = c.re.link.ReplaceAllString(s, "<a href='${1}'>${1}</a>")
+			s = c.re.codeShort.ReplaceAllString(s, "<code>${1}</code>")
+			s = c.re.del.ReplaceAllString(s, "<del>${1}</del>")
+			s = c.re.emoji.ReplaceAllStringFunc(s, c.bindEmoji)
+			s = c.re.mention.ReplaceAllStringFunc(s, c.bindUser)
+			s = c.re.channel.ReplaceAllStringFunc(s, c.bindChannel)
 		} else {
-			chunks[i] = "<pre>" + chunks[i] + "</pre>"
+			s = "<pre>" + s + "</pre>"
 		}
+		chunks[i] = s
 	}
 	return strings.Join(chunks, "")
 }

--- a/scripts/lib/generator.go
+++ b/scripts/lib/generator.go
@@ -117,11 +117,9 @@ func (g *HTMLGenerator) generateChannelDir(path string, channel Channel) (bool, 
 		return false, fmt.Errorf("could not create %s directory: %w", path, err)
 	}
 
-	keys := make([]MessageMonthKey, len(msgsMap))
-	i := 0
+	keys := make([]MessageMonthKey, 0, len(msgsMap))
 	for key := range msgsMap {
-		keys[i] = key
-		i++
+		keys = append(keys, key)
 	}
 
 	if err := g.generateChannelIndex(
@@ -132,11 +130,11 @@ func (g *HTMLGenerator) generateChannelDir(path string, channel Channel) (bool, 
 		return true, err
 	}
 
-	for key := range msgsMap {
+	for key, mm := range msgsMap {
 		if err := g.generateMessageDir(
 			channel,
 			key,
-			msgsMap[key],
+			mm,
 			filepath.Join(path, key.Year(), key.Month()),
 		); err != nil {
 			return true, err

--- a/scripts/lib/store.go
+++ b/scripts/lib/store.go
@@ -39,9 +39,9 @@ func NewLogStore(dirPath string, cfg *Config) (*LogStore, error) {
 		// processing.
 	}
 
-	mts := make(map[string]*MessageTable, len(ct.ChannelMap))
-	for channelID := range ct.ChannelMap {
-		mts[channelID] = NewMessageTable()
+	mts := make(map[string]*MessageTable, len(ct.Channels))
+	for _, ch := range ct.Channels {
+		mts[ch.ID] = NewMessageTable()
 	}
 
 	return &LogStore{

--- a/scripts/lib/user.go
+++ b/scripts/lib/user.go
@@ -19,10 +19,11 @@ func NewUserTable(path string) (*UserTable, error) {
 		return nil, err
 	}
 	userMap := make(map[string]*User, len(users))
-	for i := range users {
-		userMap[users[i].ID] = &users[i]
-		if users[i].Profile.BotID != "" {
-			userMap[users[i].Profile.BotID] = &users[i]
+	for i, u := range users {
+		pu := &users[i]
+		userMap[u.ID] = pu
+		if u.Profile.BotID != "" {
+			userMap[u.Profile.BotID] = pu
 		}
 	}
 	return &UserTable{users, userMap}, nil


### PR DESCRIPTION
いちいち `list[i]` って書いてると見通しがわるくなるため直しました。
関連して、いくつかロジックをいじってます。

* `ChannelTable` - を作るときにフィールド名がなかったので追加
* `FilterChannel` - whiltelist をあらかじめマップ化して、channelsでループして通過させるものを検出するようにした。マップ化の段階で `*` を処理したうえで二重ループが減ってるので whitelist と channels が増えても安心
* `removeToken()` - を定義して、コードの見た目をシェイプアップ
* channelsを取るタイミングをそれが必要になるギリギリまで遅延

goはコピペとかで同じ記述が増える傾向にありますが
それでもシュッと書けるところはシュッとさせて見通しを良くする文化なので。