### PR TITLE
絵文字周りの微修正

### DIFF
--- a/scripts/config.json
+++ b/scripts/config.json
@@ -3,5 +3,5 @@
   "channels": [
     "*"
   ],
-  "emoji_json": "../emojis/emoji.json"
+  "emoji_json": "../slacklog_data/emoji.json"
 }

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -3,5 +3,5 @@
   "channels": [
     "*"
   ],
-  "emoji_json": "../slacklog_data/emoji.json"
+  "emoji_json_path": "../slacklog_data/emoji.json"
 }

--- a/scripts/download_emoji.sh
+++ b/scripts/download_emoji.sh
@@ -3,4 +3,4 @@
 set -eu
 
 cd "$(dirname "$0")" || exit "$?"
-go run ./main.go download-emoji ../emojis/ ../_data/emoji.json
+go run ./main.go download-emoji ../emojis/ ../slacklog_data/emoji.json

--- a/scripts/lib/config.go
+++ b/scripts/lib/config.go
@@ -2,9 +2,9 @@ package slacklog
 
 // Config : ログ出力時の設定を保持する。
 type Config struct {
-	EditedSuffix string   `json:"edited_suffix"`
-	Channels     []string `json:"channels"`
-	EmojiJSON    string   `json:"emoji_json"`
+	EditedSuffix  string   `json:"edited_suffix"`
+	Channels      []string `json:"channels"`
+	EmojiJSONPath string   `json:"emoji_json_path"`
 }
 
 // ReadConfig : pathに指定したファイルからコンフィグを読み込む。

--- a/scripts/lib/store.go
+++ b/scripts/lib/store.go
@@ -30,7 +30,7 @@ func NewLogStore(dirPath string, cfg *Config) (*LogStore, error) {
 		return nil, err
 	}
 
-	et, err := NewEmojiTable(filepath.Join(dirPath, cfg.EmojiJSON))
+	et, err := NewEmojiTable(filepath.Join(dirPath, cfg.EmojiJSONPath))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err

--- a/scripts/lib/subcmd/download_emoji.go
+++ b/scripts/lib/subcmd/download_emoji.go
@@ -30,6 +30,10 @@ func DownloadEmoji(args []string) error {
 	}
 
 	emojisDir := filepath.Clean(args[0])
+	emojiJSONPath := filepath.Join(emojisDir, "emoji.json")
+	if 1 < len(args) {
+		emojiJSONPath = filepath.Clean(args[1])
+	}
 
 	api := slack.New(slackToken)
 
@@ -53,7 +57,7 @@ func DownloadEmoji(args []string) error {
 
 	// write `emojis` to a file as JSON, using with json.Encoder. this saves
 	// memory to marshal JSON.
-	f, err := os.Create(filepath.Join(emojisDir, "emoji.json"))
+	f, err := os.Create(emojiJSONPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
絵文字周りを微調整。

- `emoji.json` を `emojis/` に置いていたのを `slacklog_data/` に置くように変更
  - `emojis/` 以下は publish されるので。されても困らないけど、一応 JSON 置き場的な意味でも集約する
- config のキーの名前を変更
  - 単に名前がおかしいと感じたので

`log-data` ブランチ内の `emoji.json` の移動は別途行います。